### PR TITLE
Solidity syntax highlight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Hi, nice work :-) 
The change should make the syntax `RockPaperScissors.sol` colorful. 